### PR TITLE
add media query helper

### DIFF
--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -1,0 +1,15 @@
+import { css } from 'styled-components';
+
+const breakpoints = {
+  large: 1024,
+  small: 600
+};
+
+export default Object.keys(breakpoints).reduce((queries, label) => {
+  queries[label] = (...args) => css`
+    @media (min-width: ${breakpoints[label]}px) {
+      ${css(...args)};
+    }
+  `;
+  return queries;
+}, {});


### PR DESCRIPTION
@RobTF9 

Is this what you're looking for?

Implementation:

1. Add  `import media from '../utils/media'` to a file that contains a styled component
2. Add to styled component -- for example: 

```const Wrapper = styled.div`
  ${media.small`
  height: 100vh;
  width: 100vw;
    background: orange;
  `}
`;```

If using ThemeProvider from styled-components,  `media.js` can be imported there instead of in every file where components are styled.



