### PR TITLE
fix:added the proper propType to TextButton and NavLink

### DIFF
--- a/src/components/NavLink/NavLink.jsx
+++ b/src/components/NavLink/NavLink.jsx
@@ -7,7 +7,7 @@ const NavLink = ({ content, path }) => {
 };
 
 NavLink.propTypes = {
-  content: PropTypes.string.isRequired,
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   path: PropTypes.string.isRequired
 };
 

--- a/src/components/TextButton/TextButton.jsx
+++ b/src/components/TextButton/TextButton.jsx
@@ -14,7 +14,7 @@ const TextButton = ({ content, type = 'button', onClick }) => {
 };
 
 TextButton.propTypes = {
-  content: PropTypes.string.isRequired,
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   type: PropTypes.oneOf(['submit', 'button']),
   onClick: PropTypes.func
 };


### PR DESCRIPTION
Closes #107 

This has very small change. Added 'PropType.element' as content prop type for NavLink and TextButton element.